### PR TITLE
Update env.go to revert default port to 3000

### DIFF
--- a/src/helpers/env.go
+++ b/src/helpers/env.go
@@ -19,7 +19,7 @@ package helpers
 
 import "os"
 
-const defaultPort = "3005"
+const defaultPort = "3000"
 
 func GetServiceAddress() (address string) {
 	if port := os.Getenv("PORT"); port != "" {


### PR DESCRIPTION
For backwards compatibility with older versions of the helm chart


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [x] Lint has passed locally and any fixes were made for failures


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

Default port has changed to 3005 from 3000. This causes deployments that have previously unset PORT environment variable to cease working. 

Issue Number: N/A


## What is the new behavior?

This PR Reverts this change

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

